### PR TITLE
Fix tests: update config to be valid for the latest Uglify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "mock-require": "^3.0.1",
     "nock": "^9.1.6",
     "superagent": "^3.8.1",
-    "uglify-es": "^3.2.1",
+    "uglify-es": "^3.3.0",
     "validate-npm-package-name": "^3.0.0"
   },
   "bin": {

--- a/runExample.sh
+++ b/runExample.sh
@@ -5,7 +5,7 @@
 # ./runExample -c connectionExample
 # ./runExample all
 
-dir=test-project
+dir=reserved-project-name-for-automated-tests
 function runExample {
   rm -rf $dir
   sgtu-init $dir $1 $2
@@ -13,6 +13,7 @@ function runExample {
   npm run test
   if [ $? != 0 ]; then exit; fi
   cd ..
+  rm -rf $dir
 }
 
 if [ $1 == all ]

--- a/src/compressUtils.js
+++ b/src/compressUtils.js
@@ -30,7 +30,6 @@ const uglifyOpts = {
     if_return: true,
     inline: true,
     join_vars: true,
-    cascade: true,
     collapse_vars: true,
     reduce_vars: true,
     warnings: true,
@@ -278,9 +277,13 @@ function compress(code, helpers) {
   });
 
   // Minify code.
-  code = UglifyJS.minify(code, uglifyOpts).code;
+  const minifyResult = UglifyJS.minify(code, uglifyOpts);
+  if (minifyResult.error) {
+    throw new Error(`error minifying code:\n${minifyResult.error}\n${code}`);
+  }
 
   // Extract the function body so it can be executed directly.
+  code = minifyResult.code;
   code = code.replace(/^.*?{/, '').replace(/}$/, '');
   return code;
 }

--- a/test/src/compressUtils.js
+++ b/test/src/compressUtils.js
@@ -1718,6 +1718,12 @@ describe('test/compressUtils.js >', () => {
         'n,5)}))'
       );
     });
+
+    it('error in minify', () => {
+      const code = '{abc$!#';
+      const helpers = {};
+      expect(() => cu.compress(code, helpers)).to.throw('error minifying code');
+    });
   });
 
   describe('validateCtxUsages >', () => {


### PR DESCRIPTION
This should fix the tests when merged into that branch. The issue was that Uglify had been updated in a way that wasn't backwards compatible (specifically the "cascade" config variable) and I was still using the old version locally.