### PR TITLE
copy entire dependency tree, not just top-level

### DIFF
--- a/runExample.sh
+++ b/runExample.sh
@@ -5,15 +5,22 @@
 # ./runExample -c connectionExample
 # ./runExample all
 
-dir=reserved-project-name-for-automated-tests
+# This should only be called from the sgt-utils project directory
+
+newProject=reserved-project-name-for-automated-tests
+baseDir=`pwd`
 function runExample {
-  rm -rf $dir
-  sgtu-init $dir $1 $2
-  cd $dir
+  # need to go one dir up from the sgt-utils project to make sure the copy works
+  # outside the scope of its node modules
+  cd ..
+  rm -rf $newProject
+  sgtu-init $newProject $1 $2
+  cd $newProject
   npm run test
   if [ $? != 0 ]; then exit; fi
   cd ..
-  rm -rf $dir
+  cd $baseDir
+  rm -rf $newProject
 }
 
 if [ $1 == all ]

--- a/src/resourceGenUtils.js
+++ b/src/resourceGenUtils.js
@@ -44,6 +44,26 @@ const scriptsToAdd = {
   validate: 'echo "validate"',
 };
 
+/**
+ * Traverses the dependency tree to find all required modules.
+ * @param {Array} moduleNames - The top-level modules to search
+ * @param {Object} dependencyTree - A tree of modules and their dependencies
+ * @returns {Set} A flattened, unique list of dependencies
+ */
+function getAllDependencies(moduleNames, dependencyTree) {
+  let allDependencies = new Set();
+  moduleNames.forEach((moduleName) => {
+    const module = dependencyTree[moduleName];
+    if (module) allDependencies.add(moduleName);
+    const nextDependencies = module && module.dependencies;
+    if (nextDependencies) {
+      getAllDependencies(Object.keys(nextDependencies), nextDependencies)
+      .forEach((dep) => allDependencies.add(dep));
+    }
+  });
+  return allDependencies;
+}
+
 module.exports = {
   /**
    * Create a directory for the new project
@@ -120,19 +140,9 @@ module.exports = {
         fs.copySync(fromDir, toDir);
       }
     });
-
-    function getAllDependencies(moduleNames, dependencyTree) {
-      let dependencies = new Set(moduleNames);
-      moduleNames.forEach((moduleName) => {
-        const dependencyNode = dependencyTree[moduleName].dependencies;
-        if (dependencyNode) {
-          getAllDependencies(Object.keys(dependencyNode), dependencyNode)
-          .forEach((dep) => dependencies.add(dep));
-        }
-      });
-      return dependencies;
-    }
   },
+
+  getAllDependencies,
 
   /**
    * Initializes the package.json file, then adds scripts and dependencies.

--- a/test/bin/build.js
+++ b/test/bin/build.js
@@ -15,7 +15,8 @@ const fs = require('fs-extra');
 const fork = require('child_process').fork;
 const projectName = 'reserved-project-name-for-automated-tests';
 
-describe('test/bin/build.js >', () => {
+describe('test/bin/build.js >', function () {
+  this.timeout(5000);
   before((done) => {
     const args = [projectName, '-t', 'basicBulk', '-c', 'concatenateAspects'];
     const forkedProcess = fork('./bin/generateResources.js', args);

--- a/test/bin/buildConnection.js
+++ b/test/bin/buildConnection.js
@@ -15,7 +15,8 @@ const fs = require('fs-extra');
 const fork = require('child_process').fork;
 const projectName = 'reserved-project-name-for-automated-tests';
 
-describe('test/bin/buildConnection.js >', () => {
+describe('test/bin/buildConnection.js >', function () {
+  this.timeout(5000);
   before((done) => {
     const args = [projectName, '-c', 'concatenateAspects'];
     const forkedProcess = fork('./bin/generateResources.js', args);

--- a/test/bin/buildTransform.js
+++ b/test/bin/buildTransform.js
@@ -15,7 +15,8 @@ const fs = require('fs-extra');
 const fork = require('child_process').fork;
 const projectName = 'reserved-project-name-for-automated-tests';
 
-describe('test/bin/buildTransform.js >', () => {
+describe('test/bin/buildTransform.js >', function () {
+  this.timeout(5000);
   before((done) => {
     const args = [projectName, '-t', 'basicBulk'];
     const forkedProcess = fork('./bin/generateResources.js', args);

--- a/test/bin/deploy.js
+++ b/test/bin/deploy.js
@@ -15,7 +15,8 @@ const fs = require('fs-extra');
 const fork = require('child_process').fork;
 const projectName = 'reserved-project-name-for-automated-tests';
 
-describe('test/bin/deploy.js >', () => {
+describe('test/bin/deploy.js >', function () {
+  this.timeout(5000);
   before((done) => {
     const args = [projectName, '-t', 'basicBulk', '-c', 'concatenateAspects'];
     const forkedProcess = fork('./bin/generateResources.js', args);

--- a/test/bin/generateResources.js
+++ b/test/bin/generateResources.js
@@ -15,7 +15,8 @@ const fs = require('fs-extra');
 const fork = require('child_process').fork;
 const projectName = 'reserved-project-name-for-automated-tests';
 
-describe('test/bin/generateResources.js >', () => {
+describe('test/bin/generateResources.js >', function () {
+  this.timeout(5000);
   beforeEach(() => fs.remove(`./${projectName}`));
   afterEach(() => fs.remove(`./${projectName}`));
 
@@ -37,10 +38,11 @@ describe('test/bin/generateResources.js >', () => {
       expect(fs.readdirSync(`./${projectName}/utils`)).to.have.members([
         'testUtils.js',
       ]);
-      expect(fs.readdirSync(`./${projectName}/node_modules`)).to.have.members([
+      const nodeModules = fs.readdirSync(`./${projectName}/node_modules`);
+      expect(nodeModules).to.include.members([
         '@salesforce', 'chai', 'chai-url', 'fs-extra', 'istanbul', 'mocha',
       ]);
-
+      expect(nodeModules.length).to.be.gt(50);
       done();
     });
   });

--- a/test/src/resourceGenUtils.js
+++ b/test/src/resourceGenUtils.js
@@ -180,7 +180,54 @@ describe('test/src/resourceGenUtils.js >', () => {
     });
   });
 
-  describe('copyPackages >', () => {
+  describe('getAllDependencies >', () => {
+    const dependencyTree = {
+      a: { version: '1.0.0' },
+      b: {
+        version: '1.0.0',
+        dependencies: {
+          c: { version: '1.0.0' },
+          d: {
+            version: '1.0.0',
+            dependencies: {
+              e: { version: '1.0.0' },
+              f: {
+                version: '1.0.0',
+                dependencies: {
+                  g: { version: '1.0.0' },
+                },
+              },
+            },
+          },
+        },
+      },
+      h: { version: '1.0.0' },
+      i: {
+        version: '1.0.0',
+        dependencies: {
+          j: { version: '1.0.0' },
+          c: { version: '1.0.0' },
+        },
+      },
+      l: {
+        version: '1.0.0',
+        dependencies: {
+          m: { version: '1.0.0' },
+        },
+      },
+    };
+
+    it('get all dependencies', () => {
+      const modulesToCopy = ['a', 'b', 'i', 'm', 'z'];
+      const dependencies = rgu.getAllDependencies(modulesToCopy, dependencyTree);
+      expect(dependencies).to.have.keys([
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'i', 'j',
+      ]);
+    });
+  });
+
+  describe('copyPackages >', function () {
+    this.timeout(5000);
     before(() => {
       mockFs({
         'my-project': {
@@ -193,6 +240,10 @@ describe('test/src/resourceGenUtils.js >', () => {
           'fs-extra': mockDir('./node_modules/fs-extra'),
           istanbul: mockDir('./node_modules/istanbul'),
           mocha: mockDir('./node_modules/mocha'),
+          abbrev: mockDir('./node_modules/abbrev'), // dependency
+          ajv: mockDir('./node_modules/ajv'), // not dependency
+          'align-text': mockDir('./node_modules/align-text'), // dependency
+          asn1: mockDir('./node_modules/asn1'), // not dependency
         },
       });
     });
@@ -202,12 +253,11 @@ describe('test/src/resourceGenUtils.js >', () => {
     });
 
     it('packages are copied', () => {
-      expect(fs.readdirSync('./my-project/node_modules')).to.not.have.members([
-        '@salesforce', 'chai', 'chai-url', 'fs-extra', 'istanbul', 'mocha',
-      ]);
+      expect(fs.readdirSync('./my-project/node_modules')).to.be.empty;
       rgu.copyPackages();
       expect(fs.readdirSync('./my-project/node_modules')).to.have.members([
         '@salesforce', 'chai', 'chai-url', 'fs-extra', 'istanbul', 'mocha',
+        'abbrev', 'align-text',
       ]);
     });
   });

--- a/test/utils/testUtils.js
+++ b/test/utils/testUtils.js
@@ -16,7 +16,7 @@ const fork = require('child_process').fork;
 let tu;
 
 describe('test/utils/testUtils.js >', function () {
-  this.timeout(3000);
+  this.timeout(5000);
 
   function setup(transformExample, connectionExample) {
     fs.removeSync(`./${projectName}`);


### PR DESCRIPTION
Previously it was only copying over the top-level dependencies, but not the dependencies for those modules. This caused errors if you created a clean project with no existing npm modules. We didn't catch this in the tests because they were creating the new projects under the sgt-utils project, which already had all the packages in it's node_modules directory.

I changed it to copy the entire dependency tree, and updated the tests to create the new project outside of the main sgt-utils directory.