### PR TITLE
make isPublished arg work with "npm run deploy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,9 @@ It is highly recommended to put the entire project under source control, e.g. gi
 Upload your brand new sample generator template into an instance of Refocus. Note: Upload should run test and build and validate before actually uploading.
 
 ```
-$ npm run deploy TEMPLATE_FILE REFOCUS_URL REFOCUS_TOKEN --isPublished=<true|false>
+$ npm run deploy <templateFile> <isPublished> <refocusUrl> <refocusToken>
+$ npm run deploy my-sgt.json isPublished=true www.example.com abcdefghijklmnopqrstuvwxyz
 ```
-
-Use `--isPublished <true|false>` to specify whether you want your new sample generator template to be posted with "isPublished" set to true or false.
 
 ## Maintenance
 

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -20,7 +20,10 @@ commander
 .parse(process.argv);
 
 if (commander.args.length < 4) {
-  console.error('\nError: <templateFile> <isPublished=(true|false)> <refocusUrl> <refocusToken> args are required.\n');
+  console.error(
+    '\nError: <templateFile> <isPublished=(true|false)> <refocusUrl>' +
+    ' <refocusToken> args are required.\n'
+  );
   process.exit(1);
 }
 

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -16,29 +16,24 @@ const startTime = Date.now();
 const commander = require('commander');
 
 commander
-.arguments('<templateFile> <refocusUrl> <refocusToken>')
-.option('--isPublished <true|false>', 'set isPublished to true|false')
+.arguments('<templateFile> <isPublished> <refocusUrl> <refocusToken>')
 .parse(process.argv);
 
-if (commander.args.length < 3) {
-  console.error('\nError: <templateFile> <refocusUrl> <refocusToken> args are required.\n');
+if (commander.args.length < 4) {
+  console.error('\nError: <templateFile> <isPublished=(true|false)> <refocusUrl> <refocusToken> args are required.\n');
   process.exit(1);
 }
 
-if (!commander.hasOwnProperty('isPublished')) {
-  console.error('\nError: --isPublished <true|false> is required.\n');
+let [templateFile, isPublished, refocusUrl, refocusToken] = commander.args;
+
+if (!['isPublished=true', 'isPublished=false'].includes(isPublished)) {
+  console.error('\nError: isPublished must be "isPublished=<true|false>".\n');
   process.exit(1);
 }
 
-if (!['true', 'false'].includes(commander.isPublished.toLowerCase())) {
-  console.error('\nError: --isPublished <true|false> is required.\n');
-  process.exit(1);
-}
-
-const [templateFile, refocusUrl, refocusToken] = commander.args;
-const isPublished = commander.isPublished.toLowerCase() === 'true';
+isPublished = isPublished === 'isPublished=true';
 console.log(`Deploying ${templateFile} to ${refocusUrl} with ` +
-  `isPublished=${isPublished}...`);
+  `isPublished: ${isPublished}`);
 
 u.deploy(templateFile, refocusUrl, refocusToken, isPublished)
 .then(() => console.log(`Done deploying ${templateFile} to ${refocusUrl} ` +

--- a/examples/transform/basicBySubject/testTransform.js
+++ b/examples/transform/basicBySubject/testTransform.js
@@ -100,7 +100,7 @@ describe('transform tests >', () => {
         },
       };
 
-      expect(() => tu.validateResponse(res)).to.not.throw();
+      expect(() => tu.validateResponse(res)).to.throw();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-sample-generator-template-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Refocus Sample Generator Template Utilities",
   "main": "index.js",
   "dependencies": {

--- a/runExample.sh
+++ b/runExample.sh
@@ -17,7 +17,7 @@ function runExample {
   sgtu-init $newProject $1 $2
   cd $newProject
   npm run test
-  if [ $? != 0 ]; then exit; fi
+  if [ $? != 0 ]; then exit 1; fi
   cd ..
   cd $baseDir
   rm -rf $newProject

--- a/test/bin/deploy.js
+++ b/test/bin/deploy.js
@@ -35,14 +35,15 @@ describe('test/bin/deploy.js >', function () {
    */
   it('provide 3 args and isPublished flag set to false', (done) => {
     const templateFile = `./${projectName}/${projectName}.json`;
+    const isPublished = 'isPublished=false';
     const refocusUrl = 'http://localhost';
     const refocusToken = 'abcdefg';
-    const args = [templateFile, refocusUrl, refocusToken, '--isPublished=false'];
+    const args = [templateFile, isPublished, refocusUrl, refocusToken];
     const forkedProcess = fork('./bin/deploy.js', args, { silent: true });
     forkedProcess.stdout.on('data', (data) => {
       expect(data.toString())
       .to.include(`Deploying ${templateFile} to ${refocusUrl} with ` +
-        'isPublished=false...');
+        'isPublished: false');
     });
     forkedProcess.stderr.on('data', (data) => {
       expect(data.toString()).to.include('Error: connect ECONNREFUSED');
@@ -52,53 +53,46 @@ describe('test/bin/deploy.js >', function () {
 
   it('missing args', (done) => {
     const templateFile = `./${projectName}/${projectName}.json`;
+    const isPublished = 'isPublished=false';
     const refocusUrl = 'http://localhost';
     const refocusToken = 'abcdefg';
-    const args = [templateFile, refocusUrl];
+    const args = [templateFile, isPublished, refocusUrl];
     const forkedProcess = fork('./bin/deploy.js', args, { silent: true });
     forkedProcess.stderr.on('data', (data) => {
       expect(data.toString())
-      .to.include('Error: <templateFile> <refocusUrl> <refocusToken> args are required.');
+      .to.include(
+        'Error: <templateFile> <isPublished=(true|false)> <refocusUrl> ' +
+        '<refocusToken> args are required.'
+      );
       done();
     });
   });
 
-  it('missing isPublished', (done) => {
+  it('set isPublished', (done) => {
     const templateFile = `./${projectName}/${projectName}.json`;
+    const isPublished = 'isPublished=true';
     const refocusUrl = 'http://localhost';
     const refocusToken = 'abcdefg';
-    const args = [templateFile, refocusUrl, refocusToken];
-    const forkedProcess = fork('./bin/deploy.js', args, { silent: true });
-    forkedProcess.stderr.on('data', (data) => {
-      expect(data.toString())
-      .to.include('Error: --isPublished <true|false> is required.');
-      done();
-    });
-  });
-
-  it('set isPublished using long option --isPublished', (done) => {
-    const templateFile = `./${projectName}/${projectName}.json`;
-    const refocusUrl = 'http://localhost';
-    const refocusToken = 'abcdefg';
-    const args = [templateFile, refocusUrl, refocusToken, '--isPublished=true'];
+    const args = [templateFile, isPublished, refocusUrl, refocusToken];
     const forkedProcess = fork('./bin/deploy.js', args, { silent: true });
     forkedProcess.stdout.on('data', (data) => {
       expect(data.toString())
       .to.include(`Deploying ${templateFile} to ${refocusUrl} with ` +
-        'isPublished=true...');
+        'isPublished: true');
       done();
     });
   });
 
   it('invalid value for isPublished', (done) => {
     const templateFile = `./${projectName}/${projectName}.json`;
+    const isPublished = 'isPublished=foo';
     const refocusUrl = 'http://localhost';
     const refocusToken = 'abcdefg';
-    const args = [templateFile, refocusUrl, refocusToken, '--isPublished foo'];
+    const args = [templateFile, isPublished, refocusUrl, refocusToken];
     const forkedProcess = fork('./bin/deploy.js', args, { silent: true });
     forkedProcess.stderr.on('data', (data) => {
       expect(data.toString())
-      .to.include('Error: --isPublished <true|false> is required.');
+      .to.include('Error: isPublished must be "isPublished=<true|false>".');
       done();
     });
   });


### PR DESCRIPTION
previously --isPublished=true was not working because npm scripts require you to use "--" to pass options.

So you would have had to do:
npm run deploy my-sgt.json www.example.com token -- --isPublished=true

This is not very clear and there's no way around this as long as it's an option, so I decided to just make it an argument instead.

So now it's:
npm run deploy my-sgt.json isPublished=true www.example.com token